### PR TITLE
Update `certifi`, `dask`, `hypothesis`, `ipython`, `numpy`, `qtconsole`, `rich`, `scipy`, `tifffile`

### DIFF
--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -42,7 +42,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -50,7 +50,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -84,7 +84,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -95,9 +95,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -106,7 +106,7 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
@@ -118,7 +118,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -158,7 +158,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -202,7 +202,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -249,7 +249,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -352,7 +352,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -372,7 +372,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -422,12 +422,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -448,7 +447,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -460,7 +459,7 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -510,7 +509,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -550,7 +549,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -586,5 +585,5 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via importlib-metadata

--- a/resources/constraints/constraints_py3.10_docs.txt
+++ b/resources/constraints/constraints_py3.10_docs.txt
@@ -36,7 +36,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -55,7 +55,7 @@ colorama==0.4.6
     # via sphinx-autobuild
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -104,7 +104,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -119,9 +119,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via
     #   anyio
     #   requests
@@ -134,7 +134,7 @@ imageio-ffmpeg==0.5.1
     # via -r docs/requirements.txt
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
@@ -149,7 +149,7 @@ ipykernel==6.29.5
     #   myst-nb
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -203,7 +203,7 @@ lxml==5.3.0
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
     #   nilearn
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via
     #   -r docs/requirements.txt
     #   lxml
@@ -326,7 +326,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -410,7 +410,7 @@ pyautogui==0.9.54
     # via napari (napari_repo/pyproject.toml)
 pyconify==0.1.6
     # via superqt
-pydantic==1.10.17
+pydantic==1.10.18
     # via
     #   -r napari_repo/resources/constraints/pydantic_le_2.txt
     #   napari (napari_repo/pyproject.toml)
@@ -440,7 +440,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -460,7 +460,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -515,12 +515,11 @@ pyyaml==6.0.2
     #   myst-parser
     #   npe2
     #   sphinx-external-toc
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -542,7 +541,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -556,13 +555,13 @@ scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
 scikit-learn==1.5.1
     # via nilearn
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   nilearn
     #   scikit-image
     #   scikit-learn
-setuptools==72.2.0
+setuptools==74.0.0
     # via imageio-ffmpeg
 shellingham==1.5.4
     # via typer
@@ -654,7 +653,7 @@ tensorstore==0.1.64
     #   napari (napari_repo/pyproject.toml)
 threadpoolctl==3.5.0
     # via scikit-learn
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -696,7 +695,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -728,11 +727,11 @@ vispy==0.14.3
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-svg
-watchfiles==0.23.0
+watchfiles==0.24.0
     # via sphinx-autobuild
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
+websockets==13.0.1
     # via sphinx-autobuild
 wrapt==1.16.0
     # via napari (napari_repo/pyproject.toml)
@@ -742,5 +741,5 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via importlib-metadata

--- a/resources/constraints/constraints_py3.10_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.10_pydantic_1.txt
@@ -26,7 +26,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -40,7 +40,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -48,7 +48,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -82,7 +82,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -93,9 +93,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -104,7 +104,7 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
@@ -116,7 +116,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -156,7 +156,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -200,7 +200,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -247,7 +247,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -324,7 +324,7 @@ pyautogui==0.9.54
     # via napari (napari_repo/pyproject.toml)
 pyconify==0.1.6
     # via superqt
-pydantic==1.10.17
+pydantic==1.10.18
     # via
     #   -r napari_repo/resources/constraints/pydantic_le_2.txt
     #   napari (napari_repo/pyproject.toml)
@@ -349,7 +349,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -369,7 +369,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -419,12 +419,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -445,7 +444,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -457,7 +456,7 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -507,7 +506,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -547,7 +546,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -582,5 +581,5 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via importlib-metadata

--- a/resources/constraints/constraints_py3.10_windows.txt
+++ b/resources/constraints/constraints_py3.10_windows.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -50,7 +50,7 @@ colorama==0.4.6
     #   tqdm
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -58,7 +58,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -91,7 +91,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -102,9 +102,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -113,7 +113,7 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
@@ -125,7 +125,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -165,7 +165,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -211,7 +211,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -326,7 +326,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -346,7 +346,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -394,12 +394,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -420,7 +419,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -432,7 +431,7 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -482,7 +481,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -520,7 +519,7 @@ traitlets==5.14.3
     #   qtconsole
 triangle==20230923
     # via napari (napari_repo/pyproject.toml)
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -556,5 +555,5 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via importlib-metadata

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -42,7 +42,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -50,7 +50,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -79,7 +79,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -90,9 +90,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -101,7 +101,7 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via dask
 in-n-out==0.2.1
     # via app-model
@@ -111,7 +111,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -151,7 +151,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -195,7 +195,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -242,7 +242,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -345,7 +345,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -365,7 +365,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside6==6.4.2
     # via
@@ -413,12 +413,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -439,7 +438,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -451,7 +450,7 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -499,7 +498,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -533,7 +532,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -569,5 +568,5 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via importlib-metadata

--- a/resources/constraints/constraints_py3.11_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.11_pydantic_1.txt
@@ -26,7 +26,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -40,7 +40,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -48,7 +48,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -77,7 +77,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -88,9 +88,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -99,7 +99,7 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via dask
 in-n-out==0.2.1
     # via app-model
@@ -109,7 +109,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -149,7 +149,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -193,7 +193,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -240,7 +240,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -317,7 +317,7 @@ pyautogui==0.9.54
     # via napari (napari_repo/pyproject.toml)
 pyconify==0.1.6
     # via superqt
-pydantic==1.10.17
+pydantic==1.10.18
     # via
     #   -r napari_repo/resources/constraints/pydantic_le_2.txt
     #   napari (napari_repo/pyproject.toml)
@@ -342,7 +342,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -362,7 +362,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside6==6.4.2
     # via
@@ -410,12 +410,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -436,7 +435,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -448,7 +447,7 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -496,7 +495,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -530,7 +529,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -565,5 +564,5 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via importlib-metadata

--- a/resources/constraints/constraints_py3.11_windows.txt
+++ b/resources/constraints/constraints_py3.11_windows.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -50,7 +50,7 @@ colorama==0.4.6
     #   tqdm
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -58,7 +58,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -86,7 +86,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -97,9 +97,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -108,7 +108,7 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via dask
 in-n-out==0.2.1
     # via app-model
@@ -118,7 +118,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -158,7 +158,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -204,7 +204,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -319,7 +319,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -339,7 +339,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside6==6.4.2
     # via
@@ -385,12 +385,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -411,7 +410,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -423,7 +422,7 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -471,7 +470,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -503,7 +502,7 @@ traitlets==5.14.3
     #   qtconsole
 triangle==20230923
     # via napari (napari_repo/pyproject.toml)
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -539,5 +538,5 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via importlib-metadata

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -42,7 +42,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -50,7 +50,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -79,7 +79,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -90,9 +90,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -109,7 +109,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -149,7 +149,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -193,7 +193,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -240,7 +240,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -342,7 +342,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -362,7 +362,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pytest==8.3.2
     # via
@@ -400,12 +400,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -426,7 +425,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -438,11 +437,11 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
-setuptools==72.2.0
+setuptools==74.0.0
     # via torch
 shellingham==1.5.4
     # via typer
@@ -483,7 +482,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -515,7 +514,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via

--- a/resources/constraints/constraints_py3.12_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.12_pydantic_1.txt
@@ -26,7 +26,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -40,7 +40,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -48,7 +48,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -77,7 +77,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -88,9 +88,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -107,7 +107,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -147,7 +147,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -191,7 +191,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -238,7 +238,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -314,7 +314,7 @@ pyautogui==0.9.54
     # via napari (napari_repo/pyproject.toml)
 pyconify==0.1.6
     # via superqt
-pydantic==1.10.17
+pydantic==1.10.18
     # via
     #   -r napari_repo/resources/constraints/pydantic_le_2.txt
     #   napari (napari_repo/pyproject.toml)
@@ -339,7 +339,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -359,7 +359,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pytest==8.3.2
     # via
@@ -397,12 +397,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -423,7 +422,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -435,11 +434,11 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
-setuptools==72.2.0
+setuptools==74.0.0
     # via torch
 shellingham==1.5.4
     # via typer
@@ -480,7 +479,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -512,7 +511,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via

--- a/resources/constraints/constraints_py3.12_windows.txt
+++ b/resources/constraints/constraints_py3.12_windows.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -50,7 +50,7 @@ colorama==0.4.6
     #   tqdm
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -58,7 +58,7 @@ coverage==7.6.1
     #   pytest-cov
 cycler==0.12.1
     # via matplotlib
-dask==2024.8.1
+dask==2024.8.2
     # via napari (napari_repo/pyproject.toml)
 debugpy==1.8.5
     # via ipykernel
@@ -86,7 +86,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -97,9 +97,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -116,7 +116,7 @@ ipykernel==6.29.5
     # via
     #   napari-console
     #   qtconsole
-ipython==8.26.0
+ipython==8.27.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   ipykernel
@@ -156,7 +156,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -202,7 +202,7 @@ numba==0.60.0
     # via napari (napari_repo/pyproject.toml)
 numcodecs==0.13.0
     # via zarr
-numpy==2.0.1
+numpy==2.0.2
     # via
     #   napari (napari_repo/pyproject.toml)
     #   contourpy
@@ -316,7 +316,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -336,7 +336,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pytest==8.3.2
     # via
@@ -372,12 +372,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -398,7 +397,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -410,11 +409,11 @@ rpds-py==0.20.0
     #   referencing
 scikit-image==0.24.0
     # via napari (napari_repo/pyproject.toml)
-scipy==1.14.0
+scipy==1.14.1
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
-setuptools==72.2.0
+setuptools==74.0.0
     # via torch
 shellingham==1.5.4
     # via typer
@@ -455,7 +454,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -485,7 +484,7 @@ traitlets==5.14.3
     #   qtconsole
 triangle==20230923
     # via napari (napari_repo/pyproject.toml)
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via

--- a/resources/constraints/constraints_py3.9.txt
+++ b/resources/constraints/constraints_py3.9.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -42,7 +42,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -84,7 +84,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -95,9 +95,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -106,13 +106,13 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
     #   jupyter-client
     #   sphinx
-importlib-resources==6.4.3
+importlib-resources==6.4.4
     # via matplotlib
 in-n-out==0.2.1
     # via app-model
@@ -162,7 +162,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -253,7 +253,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -356,7 +356,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -376,7 +376,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -426,12 +426,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -452,7 +451,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -514,7 +513,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -554,7 +553,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -590,7 +589,7 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/resources/constraints/constraints_py3.9_examples.txt
+++ b/resources/constraints/constraints_py3.9_examples.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -42,7 +42,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -84,7 +84,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -95,9 +95,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -106,13 +106,13 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
     #   jupyter-client
     #   sphinx
-importlib-resources==6.4.3
+importlib-resources==6.4.4
     # via matplotlib
 in-n-out==0.2.1
     # via app-model
@@ -167,7 +167,7 @@ lxml==5.3.0
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
     #   nilearn
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -266,7 +266,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -373,7 +373,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -393,7 +393,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -443,12 +443,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -470,7 +469,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -538,7 +537,7 @@ tensorstore==0.1.64
     #   napari (napari_repo/pyproject.toml)
 threadpoolctl==3.5.0
     # via scikit-learn
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -578,7 +577,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -614,7 +613,7 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/resources/constraints/constraints_py3.9_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.9_pydantic_1.txt
@@ -26,7 +26,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -40,7 +40,7 @@ cloudpickle==3.0.0
     # via dask
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -82,7 +82,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -93,9 +93,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -104,13 +104,13 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
     #   jupyter-client
     #   sphinx
-importlib-resources==6.4.3
+importlib-resources==6.4.4
     # via matplotlib
 in-n-out==0.2.1
     # via app-model
@@ -160,7 +160,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -251,7 +251,7 @@ nvidia-cusparse-cu12==12.1.0.106
     #   torch
 nvidia-nccl-cu12==2.20.5
     # via torch
-nvidia-nvjitlink-cu12==12.6.20
+nvidia-nvjitlink-cu12==12.6.68
     # via
     #   nvidia-cusolver-cu12
     #   nvidia-cusparse-cu12
@@ -328,7 +328,7 @@ pyautogui==0.9.54
     # via napari (napari_repo/pyproject.toml)
 pyconify==0.1.6
     # via superqt
-pydantic==1.10.17
+pydantic==1.10.18
     # via
     #   -r napari_repo/resources/constraints/pydantic_le_2.txt
     #   napari (napari_repo/pyproject.toml)
@@ -353,7 +353,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -373,7 +373,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -423,12 +423,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -449,7 +448,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -511,7 +510,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -551,7 +550,7 @@ triangle==20230923
     # via napari (napari_repo/pyproject.toml)
 triton==3.0.0
     # via torch
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -586,7 +585,7 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/resources/constraints/constraints_py3.9_windows.txt
+++ b/resources/constraints/constraints_py3.9_windows.txt
@@ -28,7 +28,7 @@ build==1.2.1
     # via npe2
 cachey==0.2.1
     # via napari (napari_repo/pyproject.toml)
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   napari (napari_repo/pyproject.toml)
     #   requests
@@ -50,7 +50,7 @@ colorama==0.4.6
     #   tqdm
 comm==0.2.2
     # via ipykernel
-contourpy==1.2.1
+contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
     # via
@@ -91,7 +91,7 @@ flexparser==0.3.1
     # via pint
 fonttools==4.53.1
     # via matplotlib
-freetype-py==2.4.0
+freetype-py==2.5.1
     # via vispy
 fsspec==2024.6.1
     # via
@@ -102,9 +102,9 @@ heapdict==1.0.1
     # via cachey
 hsluv==5.0.4
     # via vispy
-hypothesis==6.111.1
+hypothesis==6.111.2
     # via napari (napari_repo/pyproject.toml)
-idna==3.7
+idna==3.8
     # via requests
 imageio==2.35.1
     # via
@@ -113,13 +113,13 @@ imageio==2.35.1
     #   scikit-image
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   build
     #   dask
     #   jupyter-client
     #   sphinx
-importlib-resources==6.4.3
+importlib-resources==6.4.4
     # via matplotlib
 in-n-out==0.2.1
     # via app-model
@@ -169,7 +169,7 @@ lxml==5.3.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   lxml-html-clean
-lxml-html-clean==0.2.0
+lxml-html-clean==0.2.2
     # via lxml
 magicgui==0.9.1
     # via napari (napari_repo/pyproject.toml)
@@ -330,7 +330,7 @@ pyopengl==3.1.6
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via matplotlib
 pyperclip==1.9.0
     # via mouseinfo
@@ -350,7 +350,7 @@ pyqt6-sip==13.8.0
     # via pyqt6
 pyrect==0.2.0
     # via pygetwindow
-pyscreeze==0.1.30
+pyscreeze==1.0.1
     # via pyautogui
 pyside2==5.15.2.1
     # via napari (napari_repo/pyproject.toml)
@@ -398,12 +398,11 @@ pyyaml==6.0.2
     #   napari (napari_repo/pyproject.toml)
     #   dask
     #   npe2
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-    #   qtconsole
-qtconsole==5.5.2
+qtconsole==5.6.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   napari-console
@@ -424,7 +423,7 @@ requests==2.32.3
     #   pooch
     #   pyconify
     #   sphinx
-rich==13.7.1
+rich==13.8.0
     # via
     #   napari (napari_repo/pyproject.toml)
     #   npe2
@@ -486,7 +485,7 @@ tensorstore==0.1.64
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-tifffile==2024.8.10
+tifffile==2024.8.28
     # via
     #   napari (napari_repo/pyproject.toml)
     #   scikit-image
@@ -524,7 +523,7 @@ traitlets==5.14.3
     #   qtconsole
 triangle==20230923
     # via napari (napari_repo/pyproject.toml)
-typer==0.12.4
+typer==0.12.5
     # via npe2
 typing-extensions==4.12.2
     # via
@@ -560,7 +559,7 @@ zarr==2.18.2
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)
-zipp==3.20.0
+zipp==3.20.1
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/resources/requirements_mypy.txt
+++ b/resources/requirements_mypy.txt
@@ -6,7 +6,7 @@ appdirs==1.4.4
     # via npe2
 build==1.2.1
     # via npe2
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -14,7 +14,7 @@ click==8.1.7
     # via typer
 docstring-parser==0.16
     # via magicgui
-idna==3.7
+idna==3.8
     # via requests
 magicgui==0.9.1
     # via -r napari_repo/resources/requirements_mypy.in
@@ -22,7 +22,7 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-mypy==1.11.1
+mypy==1.11.2
     # via -r napari_repo/resources/requirements_mypy.in
 mypy-extensions==1.0.0
     # via mypy
@@ -67,7 +67,7 @@ qtpy==2.4.1
     #   superqt
 requests==2.32.3
     # via pyconify
-rich==13.7.1
+rich==13.8.0
     # via
     #   npe2
     #   typer
@@ -77,13 +77,13 @@ superqt==0.6.7
     # via magicgui
 tomli-w==1.0.0
     # via npe2
-typer==0.12.4
+typer==0.12.5
     # via npe2
 types-pyyaml==6.0.12.20240808
     # via -r napari_repo/resources/requirements_mypy.in
 types-requests==2.32.0.20240712
     # via -r napari_repo/resources/requirements_mypy.in
-types-setuptools==71.1.0.20240818
+types-setuptools==74.0.0.20240831
     # via -r napari_repo/resources/requirements_mypy.in
 typing-extensions==4.12.2
     # via


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7212

Updated packages: `certifi`, `contourpy`, `dask`, `freetype-py`, `hypothesis`, `idna`, `importlib-metadata`, `ipython`, `lxml-html-clean`, `numpy`, `nvidia-nvjitlink-cu12`, `pyparsing`, `pyscreeze`, `pyzmq`, `qtconsole`, `rich`, `scipy`, `tifffile`, `typer`, `zipp`